### PR TITLE
brewのmysqlにおいてデフォルトとがstopなので、起動させてから次の実行に移るようにする

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -2,6 +2,8 @@
 
 set -ex;
 
+mysql.server start
+
 DB_USER=${1-root}
 DB_PASS=$2
 DB_NAME=${3-wpdev}


### PR DESCRIPTION
私の制作環境だとbrewでインストール済のmysqlが起動しておらず以下のエラーがでました

```
ERROR 2002 (HY000): Can't connect to local MySQL server through socket '/tmp/mysql.sock' (2)
```

ので、起動する記述を追加しました。
